### PR TITLE
🚑 Fix unsupported_grant_type

### DIFF
--- a/laravel/app.sh
+++ b/laravel/app.sh
@@ -5,4 +5,5 @@ php artisan key:generate
 # php artisan migrate
 php artisan migrate:fresh
 php artisan db:seed
+php artisan passport:install
 php-fpm

--- a/laravel/app/Http/Middleware/ApiLogin.php
+++ b/laravel/app/Http/Middleware/ApiLogin.php
@@ -22,7 +22,7 @@ class ApiLogin
             ->first();
 
         $request->merge([
-            'grand_type' => 'password',
+            'grant_type' => 'password',
             'client_id' => 2,
             'client_secret' => $secret,
         ]);


### PR DESCRIPTION
Bij #17 bleek een spelfout te zitten in `grand` / `grant` en standaard moet er een commando worden uitgevoerd bij opzetten Laravel omgeving in Docker